### PR TITLE
fix: make snapshotgeneration null safe for package.json with no dependencies

### DIFF
--- a/fhir-snapshots-package-generator-lib/src/main/java/de/gematik/fhir/snapshots/helper/DependencyGenerator.java
+++ b/fhir-snapshots-package-generator-lib/src/main/java/de/gematik/fhir/snapshots/helper/DependencyGenerator.java
@@ -107,13 +107,15 @@ public class DependencyGenerator {
                     JsonNode jsonNode = objectMapper.readTree(jsonContent);
                     JsonNode dependenciesNode = jsonNode.get("dependencies");
 
-                    dependenciesNode.fields().forEachRemaining(dependencyEntry -> {
-                        String packageName = dependencyEntry.getKey();
-                        String version = dependencyEntry.getValue().asText();
-                        if (!"hl7.fhir.r4.core".equals(packageName)) {
-                            dependencies.add(new PackageReference(packageName, version));
-                        }
-                    });
+                    if (dependenciesNode != null) {
+                        dependenciesNode.fields().forEachRemaining(dependencyEntry -> {
+                            String packageName = dependencyEntry.getKey();
+                            String version = dependencyEntry.getValue().asText();
+                            if (!"hl7.fhir.r4.core".equals(packageName)) {
+                                dependencies.add(new PackageReference(packageName, version));
+                            }
+                        });
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
Some packages, like the core packages, don't have dependencies, this PR fixes a Nullpointer caused by a missing dependency node in the package.json